### PR TITLE
Default comparator customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is an implementation of [SRFI 114 'Comparators'](//srfi.schemers.org/srfi-1
 
 For development I use [Chibi Scheme](//code.google.com/p/chibi-scheme) (the latest build from Mercurial trunk).
 
+## Extending
+
+See [this file](srfi-114/docs/extending.md) to see how to extend `default-comparator` with custom types.
+
 ## Licensing
 
 This SRFI implementation is distributed under **[3-clause BSD license](LICENSE)**.

--- a/srfi-114/docs/extending.md
+++ b/srfi-114/docs/extending.md
@@ -1,0 +1,37 @@
+# Adding custom primitive types into default comparator
+
+SRFI 114 allows the implementations to extend the definition of the `default-comparator` to handle
+other types supported by the Scheme system (e.g., sets and bags of the SRFI 113). However, it does
+not define any interface for that, leaving the decision to the implementation itself.
+
+This implementation defines a procedure `register-default-comparator!` exported by the `(srfi 114
+default-comparator)` library which takes a comparator as its single argument and registers it as one
+of the extension comparators. The extension comparators will be checked if the operand of `default-comparator`
+is not of a primitive type defined by the SRFI: the empty list, pairs, booleans, characters, strings,
+symbols, numbers, vectors, and bytevectors.
+
+The extension comparator should define any comparator procedures you wish to use (e.g., equality
+predicate if you want to check equality of your objects via `default-comparator`). It is not an error
+to leave the procedures undefined in your custom comparator if you never actually use them.
+
+According to the SRFI, `default-comparator` must define a strict order among the objects of distinct
+types. The order is the following: primitive types in the order specified by the SRFI < extension types
+in the order of their registration < any other types which are not accepted by the registered comparators.
+This order is absolute and does not depend on comparison or equality procedures defined by the registered
+comparators. (Also, do remember that the order in which the libraries are loaded is not defined.)
+
+For example, if you register _foo_ at first, and then register _bar_ after it, then all instances of
+_foo_ will be strictly greater than any bytevector, all instances of _bar_ will be strictly greater
+that any instance of _foo_, and all procedures (not registered within the default comparator) will be
+strictly greater that any instance of _bar_. Ordering between the instances of _foo_ or _bar_ is defined
+by their respective comparators. If no comparison or equality procedure is defined for _foo_, any
+instance of _bar_ will still be not equal to and greater than any instance of _foo_. However, all
+procedures will still compare equal among themselves as there is no comparator registered for them.
+
+Please note that `register-default-comparator!` is not thread-safe with respect to itself or the
+default comparator. R7RS does not specify if the libraries can be loaded concurrently (and if they
+can, what means are used for that). So even in there is some _schemed_ implementation that actually
+loads libraries concurrently, we cannot safely use mutexes from SRFI 18 (as they may not work due to
+different threading libraries being used by the implementation for loading libraries and for user
+threads). Therefore, concurrency issues are not addressed by this implementation and are left in the
+unportable domain. Fix them youself if your implementation breaks because of it. Sorry.

--- a/srfi-114/srfi/114/default-comparator.scm
+++ b/srfi-114/srfi/114/default-comparator.scm
@@ -3,6 +3,34 @@
 ;; 3-clause BSD license: http://github.com/ilammy/srfi-114/blob/master/LICENSE
 
 
+;; Default comparator extension registry ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; This facility is an implementation-private interface for extending
+;; the default comparator. It is indended to be used by implementation-
+;; specific libraries (i.e., system libraries) to register their types
+;; within the default comparator of SRFI 114.
+;;
+;; It should *not* be used by user-level libraries.
+;;
+;; Also, it is not thread-safe so add necessary synchronization to all
+;; exported procedures if you allow to load libraries concurrently.
+
+(define *comparators* '())
+(define *total-comparators* 0)
+
+(define (register-default-comparator! comparator)
+  (set! *comparators* (cons comparator *comparators*))
+  (set! *total-comparators* (+ 1 *total-comparators*)))
+
+(define (query-default-comparator object)
+  (let loop ((tested 0) (comparators *comparators*))
+    (if (null? comparators)
+        (values #f #f)
+        (if (comparator-test-type (car comparators) object)
+            (values (- *total-comparators* tested) (car comparators))
+            (loop (+ 1 tested) (cdr comparators))))))
+
+
 ;; Default comparison and hashing ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define fallback-comparator
@@ -12,8 +40,10 @@
     hash))
 
 ; This procedure defines the default ordering of objects by their types. Objects
-; of known primitive types have strict order between them. All other objects are
-; treated as equal. Primitive objects are less than any non-primitive object.
+; of known primitive types have strict order between them. Objects of registered
+; extension types have strict order between them. All other objects are treated
+; as equal. Primitive objects are less than any non-primitive object. Registered
+; extension objects are less than any non-primitive and non-extension object.
 (define (choose-default-comparator obj)
   (cond ((null? obj)       (values 0 null-comparator))
         ((pair? obj)       (values 1 pair-comparator))
@@ -24,7 +54,11 @@
         ((number? obj)     (values 6 number-comparator))
         ((vector? obj)     (values 7 vector-comparator))
         ((bytevector? obj) (values 8 bytevector-comparator))
-        (else              (values 9 fallback-comparator))))
+        (else
+          (let-values (((offset comparator) (query-default-comparator obj)))
+            (if offset
+                (values (+ 8 offset) comparator)
+                (values +inf.0 fallback-comparator))))))
 
 (define (default-equality obj1 obj2)
   (let-values (((obj1-order obj1-comparator) (choose-default-comparator obj1))

--- a/srfi-114/srfi/114/default-comparator.scm
+++ b/srfi-114/srfi/114/default-comparator.scm
@@ -5,43 +5,48 @@
 
 ;; Default comparison and hashing ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-syntax type-ordered-comparison-procedure
-  (syntax-rules (else)
-    ((_ (obj1 obj2) (type? compare) ... (else . body))
-     (lambda (obj1 obj2)
-       (cond ((type? obj1) (if (type? obj2) (compare obj1 obj2) -1)) ...
-             (else . body))))))
+(define fallback-comparator
+  (make-comparator #t
+    (lambda (a b) #t)
+    (lambda (a b) 0)
+    hash))
 
-(define (fallback-comparison obj1 obj2) 0)
+; This procedure defines the default ordering of objects by their types. Objects
+; of known primitive types have strict order between them. All other objects are
+; treated as equal. Primitive objects are less than any non-primitive object.
+(define (choose-default-comparator obj)
+  (cond ((null? obj)       (values 0 null-comparator))
+        ((pair? obj)       (values 1 pair-comparator))
+        ((boolean? obj)    (values 2 boolean-comparator))
+        ((char? obj)       (values 3 char-comparator))
+        ((string? obj)     (values 4 string-comparator))
+        ((symbol? obj)     (values 5 symbol-comparator))
+        ((number? obj)     (values 6 number-comparator))
+        ((vector? obj)     (values 7 vector-comparator))
+        ((bytevector? obj) (values 8 bytevector-comparator))
+        (else              (values 9 fallback-comparator))))
 
-(define default-comparison
-  (type-ordered-comparison-procedure (obj1 obj2)
-    (null?       null-comparison)
-    (pair?       pair-comparison)
-    (boolean?    boolean-comparison)
-    (char?       char-comparison)
-    (string?     string-comparison)
-    (symbol?     symbol-comparison)
-    (number?     complex-number-comparison)
-    (vector?     vector-comparison)
-    (bytevector? bytevector-comparison)
-    (else
-      (fallback-comparison obj1 obj2))))
+(define (default-equality obj1 obj2)
+  (let-values (((obj1-order obj1-comparator) (choose-default-comparator obj1))
+               ((obj2-order obj2-comparator) (choose-default-comparator obj2)))
+    (if (= obj1-order obj2-order)
+        (comparator-equal? obj1-comparator obj1 obj2)
+        #f)))
+
+(define (default-comparison obj1 obj2)
+  (let-values (((obj1-order obj1-comparator) (choose-default-comparator obj1))
+               ((obj2-order obj2-comparator) (choose-default-comparator obj2)))
+    (cond ((< obj1-order obj2-order) -1)
+          ((> obj1-order obj2-order) +1)
+          (else
+            (comparator-compare obj1-comparator obj1 obj2)))))
 
 (define (default-hash obj)
-  (cond ((null? obj)       (hash-by-identity obj))
-        ((pair? obj)       (hash obj))
-        ((boolean? obj)    (hash-by-identity obj))
-        ((char? obj)       (hash obj))
-        ((string? obj)     (string-hash obj))
-        ((symbol? obj)     (hash-by-identity obj))
-        ((number? obj)     (hash obj))
-        ((vector? obj)     (hash obj))
-        ((bytevector? obj) (hash obj))
-        (else              (hash obj))))
+  (let-values (((order comparator) (choose-default-comparator obj)))
+    (comparator-hash comparator obj)))
 
 
 ;; The default comparator ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define default-comparator
-  (make-comparator #t #t default-comparison default-hash))
+  (make-comparator #t default-equality default-comparison default-hash))

--- a/srfi-114/srfi/114/default-comparator.sld
+++ b/srfi-114/srfi/114/default-comparator.sld
@@ -1,0 +1,4 @@
+(define-library (srfi 114 default-comparator)
+  (export register-default-comparator!)
+
+  (import (srfi 114 exported)))

--- a/srfi-114/srfi/114/exported.sld
+++ b/srfi-114/srfi/114/exported.sld
@@ -1,4 +1,4 @@
-(define-library (srfi 114)
+(define-library (srfi 114 exported)
   (export comparator? comparator-comparison-procedure?
    comparator-hash-function? boolean-comparator char-comparator
    char-ci-comparator string-comparator string-ci-comparator
@@ -21,6 +21,19 @@
    make-comparison=/< make-comparison=/> make= make< make> make<= make>=
    if3 if=? if<? if>? if<=? if>=? if-not=? =? <? >? <=? >=?
    in-open-interval? in-closed-interval? in-open-closed-interval?
-   in-closed-open-interval?)
+   in-closed-open-interval? register-default-comparator!)
 
-  (import (srfi 114 exported)))
+  (import (scheme base)
+          (scheme case-lambda)
+          (scheme char)
+          (scheme complex)
+          (scheme inexact)
+          (only (srfi 69) hash hash-by-identity string-hash string-ci-hash))
+
+  (include "types.scm"
+           "default-comparator.scm"
+           "comparison-utils.scm"
+           "standard-comparisons.scm"
+           "standard-comparators.scm"
+           "constructors.scm"
+           "debug-comparator.scm"))

--- a/srfi-114/srfi/114/standard-comparators.scm
+++ b/srfi-114/srfi/114/standard-comparators.scm
@@ -5,6 +5,9 @@
 
 ;; Standard comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define null-comparator
+  (make-comparator null? #t null-comparison hash-by-identity))
+
 (define boolean-comparator
   (make-comparator boolean? boolean=? boolean-comparison hash-by-identity))
 

--- a/srfi-114/srfi/114/standard-comparisons.scm
+++ b/srfi-114/srfi/114/standard-comparisons.scm
@@ -56,12 +56,16 @@
   (make-pair-comparison default-comparison default-comparison))
 
 (define (make-improper-list-comparison compare)
-  (define pair-comparison (make-pair-comparison compare compare))
-  (type-ordered-comparison-procedure (obj1 obj2)
-    (null? null-comparison)
-    (pair? pair-comparison)
-    (else
-      (compare obj1 obj2))))
+  (define (choose-improper-comparison obj)
+    (cond ((null? obj) (values 0 null-comparison))
+          ((pair? obj) (values 1 pair-comparison))
+          (else        (values 2 compare))))
+  (lambda (obj1 obj2)
+    (let-values (((obj1-order obj1-compare) (choose-improper-comparison obj1))
+                 ((obj2-order obj2-compare) (choose-improper-comparison obj2)))
+      (cond ((< obj1-order obj2-order) -1)
+            ((> obj1-order obj2-order) +1)
+            (else (obj1-compare obj1 obj2))))))
 
 
 ;; Lists ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/srfi-114/test/srfi-114-tests.scm
+++ b/srfi-114/test/srfi-114-tests.scm
@@ -81,6 +81,7 @@
 (test-group "The default comparator"
   ; TODO: extend default-comparator to sets and bags from SRFI 113
   (test #t (<? default-comparator '() '(a . d) '#false #\space "string" 'zorro 42 #(9) #u8() cons))
+  (test #t (>? default-comparator cons #u8() #(9) 42 'zorro "string" #\space '#false '(a . d) '()))
   (test #t (<? default-comparator '(a . 1) '(a . 2)))
   (test #f (<? default-comparator '(a . 1) '(a . 1)))
   (test #t (<? default-comparator '(a . 20) '(b . 3)))
@@ -292,7 +293,10 @@
     (define improper-comparator (make-improper-list-comparator default-comparator))
     (test #t (<? improper-comparator '() '(a . b) 1 2 3))
     (test #t (<? improper-comparator '(a . ()) '(a . b)))
-    (test #t (<? improper-comparator '(a b c) '(a b . c))))
+    (test #t (<? improper-comparator '(a b c) '(a b . c)))
+    (test #t (>? improper-comparator 3 2 1 '(a . b) '()))
+    (test #t (>? improper-comparator '(a . b) '(a . ())))
+    (test #t (>? improper-comparator '(a b . c) '(a b c))))
 
   (test-group "make-{selecting,refining,reverse}-comparator"
     ;; make-selecting-comparator


### PR DESCRIPTION
Added a private interface for extending the default comparator (issue #3). This is (in all ways) similar to the solution from the reference implementation. Other libraries (e.g., SRFI 113) should call `(register-default-comparator! my-custom-comparator)` to have it installed into the global list of custom comparators. This is the primary use-case for this interface. That's why the installation is irrevocable. See more ranting in docs/extending.md.
