### PR TITLE
Equality improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
 
 install:
   - ./tools/install-chibi
+  - ./tools/install-dependencies
   - ./tools/install-self
 
 script:

--- a/srfi-114/srfi/114/constructors.scm
+++ b/srfi-114/srfi/114/constructors.scm
@@ -79,14 +79,6 @@
 
 ;; Pair comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (make-car-comparison compare)
-  (lambda (pair1 pair2)
-    (compare (car pair1) (car pair2))))
-
-(define (make-cdr-comparison compare)
-  (lambda (pair1 pair2)
-    (compare (cdr pair1) (cdr pair2))))
-
 (define (make-car-comparator comparator)
   (make-comparator pair? #t
     (make-car-comparison (comparator-comparison-procedure comparator))

--- a/srfi-114/srfi/114/constructors.scm
+++ b/srfi-114/srfi/114/constructors.scm
@@ -39,7 +39,7 @@
 (define (make-inexact-real-comparator epsilon rounding nan-handling)
   (make-comparator number? #t
     (make-inexact-real-comparison epsilon rounding nan-handling)
-    hash))
+    srfi-69:hash))
 
 
 ;; Collection comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -50,7 +50,7 @@
       (comparator-equality-predicate element-comparator))
     (make-list-comparison
       (comparator-comparison-procedure element-comparator))
-    hash))
+    srfi-69:hash))
 
 (define (make-vector-comparator element-comparator)
   (make-comparator vector?
@@ -58,7 +58,7 @@
       (comparator-equality-predicate element-comparator))
     (make-vector-comparison
       (comparator-comparison-procedure element-comparator))
-    hash))
+    srfi-69:hash))
 
 (define (make-bytevector-comparator element-comparator)
   (make-comparator bytevector?
@@ -66,7 +66,7 @@
       (comparator-equality-predicate element-comparator))
     (make-bytevector-comparison
       (comparator-comparison-procedure element-comparator))
-    hash))
+    srfi-69:hash))
 
 (define (make-listwise-comparator type-test element-comparator empty? head tail)
   (make-comparator type-test
@@ -76,7 +76,7 @@
     (make-listwise-comparison
       (comparator-comparison-procedure element-comparator)
       empty? head tail)
-    hash))
+    srfi-69:hash))
 
 (define (make-vectorwise-comparator type-test element-comparator length ref)
   (make-comparator type-test
@@ -86,7 +86,7 @@
     (make-vectorwise-comparison
       (comparator-comparison-procedure element-comparator)
       length ref)
-    hash))
+    srfi-69:hash))
 
 
 ;; Pair comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -95,13 +95,13 @@
   (make-comparator pair?
     (make-car-equality (comparator-equality-predicate comparator))
     (make-car-comparison (comparator-comparison-procedure comparator))
-    (lambda (pair) (hash (car pair)))))
+    (lambda (pair) (srfi-69:hash (car pair)))))
 
 (define (make-cdr-comparator comparator)
   (make-comparator pair?
     (make-cdr-equality (comparator-equality-predicate comparator))
     (make-cdr-comparison (comparator-comparison-procedure comparator))
-    (lambda (pair) (hash (cdr pair)))))
+    (lambda (pair) (srfi-69:hash (cdr pair)))))
 
 (define (make-pair-comparator car-comparator cdr-comparator)
   (make-comparator pair?
@@ -111,7 +111,7 @@
     (make-pair-comparison
       (comparator-comparison-procedure car-comparator)
       (comparator-comparison-procedure cdr-comparator))
-    hash))
+    srfi-69:hash))
 
 (define (make-improper-list-comparator element-comparator)
   (make-comparator #t

--- a/srfi-114/srfi/114/constructors.scm
+++ b/srfi-114/srfi/114/constructors.scm
@@ -39,7 +39,7 @@
 (define (make-inexact-real-comparator epsilon rounding nan-handling)
   (make-comparator number? #t
     (make-inexact-real-comparison epsilon rounding nan-handling)
-    srfi-69:hash))
+    real-number-hash))
 
 
 ;; Collection comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/srfi-114/srfi/114/constructors.scm
+++ b/srfi-114/srfi/114/constructors.scm
@@ -45,32 +45,44 @@
 ;; Collection comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (make-list-comparator element-comparator)
-  (make-comparator list? #t
+  (make-comparator list?
+    (make-list-equality
+      (comparator-equality-predicate element-comparator))
     (make-list-comparison
       (comparator-comparison-procedure element-comparator))
     hash))
 
 (define (make-vector-comparator element-comparator)
-  (make-comparator vector? #t
+  (make-comparator vector?
+    (make-vector-equality
+      (comparator-equality-predicate element-comparator))
     (make-vector-comparison
       (comparator-comparison-procedure element-comparator))
     hash))
 
 (define (make-bytevector-comparator element-comparator)
-  (make-comparator bytevector? #t
+  (make-comparator bytevector?
+    (make-bytevector-equality
+      (comparator-equality-predicate element-comparator))
     (make-bytevector-comparison
       (comparator-comparison-procedure element-comparator))
     hash))
 
 (define (make-listwise-comparator type-test element-comparator empty? head tail)
-  (make-comparator type-test #t
+  (make-comparator type-test
+    (make-listwise-equality
+      (comparator-equality-predicate element-comparator)
+      empty? head tail)
     (make-listwise-comparison
       (comparator-comparison-procedure element-comparator)
       empty? head tail)
     hash))
 
 (define (make-vectorwise-comparator type-test element-comparator length ref)
-  (make-comparator type-test #t
+  (make-comparator type-test
+    (make-vectorwise-equality
+      (comparator-equality-predicate element-comparator)
+      length ref)
     (make-vectorwise-comparison
       (comparator-comparison-procedure element-comparator)
       length ref)
@@ -80,24 +92,31 @@
 ;; Pair comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (make-car-comparator comparator)
-  (make-comparator pair? #t
+  (make-comparator pair?
+    (make-car-equality (comparator-equality-predicate comparator))
     (make-car-comparison (comparator-comparison-procedure comparator))
     (lambda (pair) (hash (car pair)))))
 
 (define (make-cdr-comparator comparator)
-  (make-comparator pair? #t
+  (make-comparator pair?
+    (make-cdr-equality (comparator-equality-predicate comparator))
     (make-cdr-comparison (comparator-comparison-procedure comparator))
     (lambda (pair) (hash (cdr pair)))))
 
 (define (make-pair-comparator car-comparator cdr-comparator)
-  (make-comparator pair? #t
+  (make-comparator pair?
+    (make-pair-equality
+      (comparator-equality-predicate car-comparator)
+      (comparator-equality-predicate cdr-comparator))
     (make-pair-comparison
       (comparator-comparison-procedure car-comparator)
       (comparator-comparison-procedure cdr-comparator))
     hash))
 
 (define (make-improper-list-comparator element-comparator)
-  (make-comparator #t #t
+  (make-comparator #t
+    (make-improper-list-equality
+      (comparator-equality-predicate element-comparator))
     (make-improper-list-comparison
       (comparator-comparison-procedure element-comparator))
     default-hash))

--- a/srfi-114/srfi/114/constructors.scm
+++ b/srfi-114/srfi/114/constructors.scm
@@ -50,7 +50,8 @@
       (comparator-equality-predicate element-comparator))
     (make-list-comparison
       (comparator-comparison-procedure element-comparator))
-    srfi-69:hash))
+    (make-list-hash
+      (comparator-hash-function element-comparator))))
 
 (define (make-vector-comparator element-comparator)
   (make-comparator vector?
@@ -58,7 +59,8 @@
       (comparator-equality-predicate element-comparator))
     (make-vector-comparison
       (comparator-comparison-procedure element-comparator))
-    srfi-69:hash))
+    (make-vector-hash
+      (comparator-hash-function element-comparator))))
 
 (define (make-bytevector-comparator element-comparator)
   (make-comparator bytevector?
@@ -66,7 +68,8 @@
       (comparator-equality-predicate element-comparator))
     (make-bytevector-comparison
       (comparator-comparison-procedure element-comparator))
-    srfi-69:hash))
+    (make-bytevector-hash
+      (comparator-hash-function element-comparator))))
 
 (define (make-listwise-comparator type-test element-comparator empty? head tail)
   (make-comparator type-test
@@ -76,7 +79,9 @@
     (make-listwise-comparison
       (comparator-comparison-procedure element-comparator)
       empty? head tail)
-    srfi-69:hash))
+    (make-listwise-hash
+      (comparator-hash-function element-comparator)
+      empty? head tail)))
 
 (define (make-vectorwise-comparator type-test element-comparator length ref)
   (make-comparator type-test
@@ -86,7 +91,9 @@
     (make-vectorwise-comparison
       (comparator-comparison-procedure element-comparator)
       length ref)
-    srfi-69:hash))
+    (make-vectorwise-hash
+      (comparator-hash-function element-comparator)
+      length ref)))
 
 
 ;; Pair comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -95,13 +102,13 @@
   (make-comparator pair?
     (make-car-equality (comparator-equality-predicate comparator))
     (make-car-comparison (comparator-comparison-procedure comparator))
-    (lambda (pair) (srfi-69:hash (car pair)))))
+    (make-car-hash (comparator-hash-function comparator))))
 
 (define (make-cdr-comparator comparator)
   (make-comparator pair?
     (make-cdr-equality (comparator-equality-predicate comparator))
     (make-cdr-comparison (comparator-comparison-procedure comparator))
-    (lambda (pair) (srfi-69:hash (cdr pair)))))
+    (make-cdr-hash (comparator-hash-function comparator))))
 
 (define (make-pair-comparator car-comparator cdr-comparator)
   (make-comparator pair?
@@ -111,7 +118,8 @@
     (make-pair-comparison
       (comparator-comparison-procedure car-comparator)
       (comparator-comparison-procedure cdr-comparator))
-    srfi-69:hash))
+    (make-pair-hash (comparator-hash-function car-comparator)
+                    (comparator-hash-function cdr-comparator))))
 
 (define (make-improper-list-comparator element-comparator)
   (make-comparator #t
@@ -119,7 +127,8 @@
       (comparator-equality-predicate element-comparator))
     (make-improper-list-comparison
       (comparator-comparison-procedure element-comparator))
-    default-hash))
+    (make-improper-list-hash
+      (comparator-hash-function element-comparator))))
 
 
 ;; Selecting & refining comparators: type refining ;;;;;;;;;;;;;;;;;;;;;

--- a/srfi-114/srfi/114/default-comparator.scm
+++ b/srfi-114/srfi/114/default-comparator.scm
@@ -37,7 +37,7 @@
   (make-comparator #t
     (lambda (a b) #t)
     (lambda (a b) 0)
-    hash))
+    srfi-69:hash))
 
 ; This procedure defines the default ordering of objects by their types. Objects
 ; of known primitive types have strict order between them. Objects of registered

--- a/srfi-114/srfi/114/exported.sld
+++ b/srfi-114/srfi/114/exported.sld
@@ -28,7 +28,9 @@
           (scheme char)
           (scheme complex)
           (scheme inexact)
-          (only (srfi 69) hash hash-by-identity string-hash string-ci-hash))
+          (prefix
+            (only (srfi 69) hash hash-by-identity string-hash string-ci-hash)
+            srfi-69:))
 
   (include "types.scm"
            "default-comparator.scm"

--- a/srfi-114/srfi/114/exported.sld
+++ b/srfi-114/srfi/114/exported.sld
@@ -28,6 +28,7 @@
           (scheme char)
           (scheme complex)
           (scheme inexact)
+          (only (srfi 60) bitwise-xor)
           (prefix
             (only (srfi 69) hash hash-by-identity string-hash string-ci-hash)
             srfi-69:))

--- a/srfi-114/srfi/114/exported.sld
+++ b/srfi-114/srfi/114/exported.sld
@@ -33,7 +33,7 @@
   (include "types.scm"
            "default-comparator.scm"
            "comparison-utils.scm"
-           "standard-comparisons.scm"
+           "standard-procedures.scm"
            "standard-comparators.scm"
            "constructors.scm"
            "debug-comparator.scm"))

--- a/srfi-114/srfi/114/standard-comparators.scm
+++ b/srfi-114/srfi/114/standard-comparators.scm
@@ -45,16 +45,16 @@
   (make-comparator number? complex-number-equality complex-number-comparison hash))
 
 (define pair-comparator
-  (make-comparator pair? #t pair-comparison hash))
+  (make-comparator pair? pair-equality pair-comparison hash))
 
 (define list-comparator
-  (make-comparator list? #t list-comparison hash))
+  (make-comparator list? list-equality list-comparison hash))
 
 (define vector-comparator
-  (make-comparator vector? #t vector-comparison hash))
+  (make-comparator vector? vector-equality vector-comparison hash))
 
 (define bytevector-comparator
-  (make-comparator bytevector? #t bytevector-comparison hash))
+  (make-comparator bytevector? bytevector-equality bytevector-comparison hash))
 
 
 ;; Wrapped equality predicates ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/srfi-114/srfi/114/standard-comparators.scm
+++ b/srfi-114/srfi/114/standard-comparators.scm
@@ -6,43 +6,43 @@
 ;; Standard comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define null-comparator
-  (make-comparator null? null-equality null-comparison srfi-69:hash-by-identity))
+  (make-comparator null? null-equality null-comparison null-hash))
 
 (define boolean-comparator
-  (make-comparator boolean? boolean-equality boolean-comparison srfi-69:hash-by-identity))
+  (make-comparator boolean? boolean-equality boolean-comparison boolean-hash))
 
 (define char-comparator
-  (make-comparator char? char-equality char-comparison srfi-69:hash))
+  (make-comparator char? char-equality char-comparison char-hash))
 
 (define char-ci-comparator
-  (make-comparator char? char-ci-equality char-ci-comparison srfi-69:hash))
+  (make-comparator char? char-ci-equality char-ci-comparison char-ci-hash))
 
 (define string-comparator
-  (make-comparator string? string-equality string-comparison srfi-69:string-hash))
+  (make-comparator string? string-equality string-comparison string-hash))
 
 (define string-ci-comparator
-  (make-comparator string? string-ci-equality string-ci-comparison srfi-69:string-ci-hash))
+  (make-comparator string? string-ci-equality string-ci-comparison string-ci-hash))
 
 (define symbol-comparator
-  (make-comparator symbol? symbol-equality symbol-comparison srfi-69:hash-by-identity))
+  (make-comparator symbol? symbol-equality symbol-comparison symbol-hash))
 
 (define exact-integer-comparator
-  (make-comparator exact-integer? real-number-equality real-number-comparison srfi-69:hash))
+  (make-comparator exact-integer? real-number-equality real-number-comparison real-number-hash))
 
 (define integer-comparator
-  (make-comparator integer? real-number-equality real-number-comparison srfi-69:hash))
+  (make-comparator integer? real-number-equality real-number-comparison real-number-hash))
 
 (define rational-comparator
-  (make-comparator rational? real-number-equality real-number-comparison srfi-69:hash))
+  (make-comparator rational? real-number-equality real-number-comparison real-number-hash))
 
 (define real-comparator
-  (make-comparator real? real-number-equality real-number-comparison srfi-69:hash))
+  (make-comparator real? real-number-equality real-number-comparison real-number-hash))
 
 (define complex-comparator
-  (make-comparator complex? complex-number-equality complex-number-comparison srfi-69:hash))
+  (make-comparator complex? complex-number-equality complex-number-comparison complex-number-hash))
 
 (define number-comparator
-  (make-comparator number? complex-number-equality complex-number-comparison srfi-69:hash))
+  (make-comparator number? complex-number-equality complex-number-comparison complex-number-hash))
 
 (define pair-comparator
   (make-comparator pair? pair-equality pair-comparison srfi-69:hash))

--- a/srfi-114/srfi/114/standard-comparators.scm
+++ b/srfi-114/srfi/114/standard-comparators.scm
@@ -6,59 +6,59 @@
 ;; Standard comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define null-comparator
-  (make-comparator null? null-equality null-comparison hash-by-identity))
+  (make-comparator null? null-equality null-comparison srfi-69:hash-by-identity))
 
 (define boolean-comparator
-  (make-comparator boolean? boolean-equality boolean-comparison hash-by-identity))
+  (make-comparator boolean? boolean-equality boolean-comparison srfi-69:hash-by-identity))
 
 (define char-comparator
-  (make-comparator char? char-equality char-comparison hash))
+  (make-comparator char? char-equality char-comparison srfi-69:hash))
 
 (define char-ci-comparator
-  (make-comparator char? char-ci-equality char-ci-comparison hash))
+  (make-comparator char? char-ci-equality char-ci-comparison srfi-69:hash))
 
 (define string-comparator
-  (make-comparator string? string-equality string-comparison string-hash))
+  (make-comparator string? string-equality string-comparison srfi-69:string-hash))
 
 (define string-ci-comparator
-  (make-comparator string? string-ci-equality string-ci-comparison string-ci-hash))
+  (make-comparator string? string-ci-equality string-ci-comparison srfi-69:string-ci-hash))
 
 (define symbol-comparator
-  (make-comparator symbol? symbol-equality symbol-comparison hash-by-identity))
+  (make-comparator symbol? symbol-equality symbol-comparison srfi-69:hash-by-identity))
 
 (define exact-integer-comparator
-  (make-comparator exact-integer? real-number-equality real-number-comparison hash))
+  (make-comparator exact-integer? real-number-equality real-number-comparison srfi-69:hash))
 
 (define integer-comparator
-  (make-comparator integer? real-number-equality real-number-comparison hash))
+  (make-comparator integer? real-number-equality real-number-comparison srfi-69:hash))
 
 (define rational-comparator
-  (make-comparator rational? real-number-equality real-number-comparison hash))
+  (make-comparator rational? real-number-equality real-number-comparison srfi-69:hash))
 
 (define real-comparator
-  (make-comparator real? real-number-equality real-number-comparison hash))
+  (make-comparator real? real-number-equality real-number-comparison srfi-69:hash))
 
 (define complex-comparator
-  (make-comparator complex? complex-number-equality complex-number-comparison hash))
+  (make-comparator complex? complex-number-equality complex-number-comparison srfi-69:hash))
 
 (define number-comparator
-  (make-comparator number? complex-number-equality complex-number-comparison hash))
+  (make-comparator number? complex-number-equality complex-number-comparison srfi-69:hash))
 
 (define pair-comparator
-  (make-comparator pair? pair-equality pair-comparison hash))
+  (make-comparator pair? pair-equality pair-comparison srfi-69:hash))
 
 (define list-comparator
-  (make-comparator list? list-equality list-comparison hash))
+  (make-comparator list? list-equality list-comparison srfi-69:hash))
 
 (define vector-comparator
-  (make-comparator vector? vector-equality vector-comparison hash))
+  (make-comparator vector? vector-equality vector-comparison srfi-69:hash))
 
 (define bytevector-comparator
-  (make-comparator bytevector? bytevector-equality bytevector-comparison hash))
+  (make-comparator bytevector? bytevector-equality bytevector-comparison srfi-69:hash))
 
 
 ;; Wrapped equality predicates ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define eq-comparator    (make-comparator #t eq?    #f hash-by-identity))
-(define eqv-comparator   (make-comparator #t eqv?   #f hash))
-(define equal-comparator (make-comparator #t equal? #f hash))
+(define eq-comparator    (make-comparator #t eq?    #f srfi-69:hash-by-identity))
+(define eqv-comparator   (make-comparator #t eqv?   #f srfi-69:hash))
+(define equal-comparator (make-comparator #t equal? #f srfi-69:hash))

--- a/srfi-114/srfi/114/standard-comparators.scm
+++ b/srfi-114/srfi/114/standard-comparators.scm
@@ -6,43 +6,43 @@
 ;; Standard comparators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define null-comparator
-  (make-comparator null? #t null-comparison hash-by-identity))
+  (make-comparator null? null-equality null-comparison hash-by-identity))
 
 (define boolean-comparator
-  (make-comparator boolean? boolean=? boolean-comparison hash-by-identity))
+  (make-comparator boolean? boolean-equality boolean-comparison hash-by-identity))
 
 (define char-comparator
-  (make-comparator char? char=? char-comparison hash))
+  (make-comparator char? char-equality char-comparison hash))
 
 (define char-ci-comparator
-  (make-comparator char? char-ci=? char-ci-comparison hash))
+  (make-comparator char? char-ci-equality char-ci-comparison hash))
 
 (define string-comparator
-  (make-comparator string? string=? string-comparison string-hash))
+  (make-comparator string? string-equality string-comparison string-hash))
 
 (define string-ci-comparator
-  (make-comparator string? string-ci=? string-ci-comparison string-ci-hash))
+  (make-comparator string? string-ci-equality string-ci-comparison string-ci-hash))
 
 (define symbol-comparator
-  (make-comparator symbol? symbol=? symbol-comparison hash-by-identity))
+  (make-comparator symbol? symbol-equality symbol-comparison hash-by-identity))
 
 (define exact-integer-comparator
-  (make-comparator exact-integer? = real-number-comparison hash))
+  (make-comparator exact-integer? real-number-equality real-number-comparison hash))
 
 (define integer-comparator
-  (make-comparator integer? = real-number-comparison hash))
+  (make-comparator integer? real-number-equality real-number-comparison hash))
 
 (define rational-comparator
-  (make-comparator rational? = real-number-comparison hash))
+  (make-comparator rational? real-number-equality real-number-comparison hash))
 
 (define real-comparator
-  (make-comparator real? = real-number-comparison hash))
+  (make-comparator real? real-number-equality real-number-comparison hash))
 
 (define complex-comparator
-  (make-comparator complex? = complex-number-comparison hash))
+  (make-comparator complex? complex-number-equality complex-number-comparison hash))
 
 (define number-comparator
-  (make-comparator number? = complex-number-comparison hash))
+  (make-comparator number? complex-number-equality complex-number-comparison hash))
 
 (define pair-comparator
   (make-comparator pair? #t pair-comparison hash))

--- a/srfi-114/srfi/114/standard-comparators.scm
+++ b/srfi-114/srfi/114/standard-comparators.scm
@@ -45,16 +45,16 @@
   (make-comparator number? complex-number-equality complex-number-comparison complex-number-hash))
 
 (define pair-comparator
-  (make-comparator pair? pair-equality pair-comparison srfi-69:hash))
+  (make-comparator pair? pair-equality pair-comparison pair-hash))
 
 (define list-comparator
-  (make-comparator list? list-equality list-comparison srfi-69:hash))
+  (make-comparator list? list-equality list-comparison list-hash))
 
 (define vector-comparator
-  (make-comparator vector? vector-equality vector-comparison srfi-69:hash))
+  (make-comparator vector? vector-equality vector-comparison vector-hash))
 
 (define bytevector-comparator
-  (make-comparator bytevector? bytevector-equality bytevector-comparison srfi-69:hash))
+  (make-comparator bytevector? bytevector-equality bytevector-comparison bytevector-hash))
 
 
 ;; Wrapped equality predicates ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/srfi-114/srfi/114/standard-procedures.scm
+++ b/srfi-114/srfi/114/standard-procedures.scm
@@ -1,4 +1,4 @@
-;; standard-comparisons.scm -- standard comparison definitions and constructors
+;; standard-procedures.scm -- standard comparator procedures and constructors
 ;; Copyright (c) 2015 ilammy <a.lozovsky@gmail.com>
 ;; 3-clause BSD license: http://github.com/ilammy/srfi-114/blob/master/LICENSE
 
@@ -10,39 +10,76 @@
 
 ;; Primitive types ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define (null-equality null1 null2) #t)
+
 (define (null-comparison null1 null2) 0)
+
+(define (boolean-equality bool1 bool2)
+  (eq? bool1 bool2))
 
 (define (boolean-comparison bool1 bool2)
   (if (eq? bool1 bool2) 0
       (if (eq? bool1 #f) -1 +1)))
 
+(define (char-equality char1 char2)
+  (char=? char1 char2))
+
 (define (char-comparison char1 char2)
   (if (char=? char1 char2) 0
       (if (char<? char1 char2) -1 +1)))
+
+(define (char-ci-equality char1 char2)
+  (char-ci=? char1 char2))
 
 (define (char-ci-comparison char1 char2)
   (if (char-ci=? char1 char2) 0
       (if (char-ci<? char1 char2) -1 +1)))
 
+(define (string-equality str1 str2)
+  (string=? str1 str2))
+
 (define (string-comparison str1 str2)
   (if (string=? str1 str2) 0
       (if (string<? str1 str2) -1 +1)))
+
+(define (string-ci-equality str1 str2)
+  (string-ci=? str1 str2))
 
 (define (string-ci-comparison str1 str2)
   (if (string-ci=? str1 str2) 0
       (if (string-ci<? str1 str2) -1 +1)))
 
+(define (symbol-equality sym1 sym2)
+  (symbol=? sym1 sym2))
+
 (define (symbol-comparison sym1 sym2)
   (if (symbol=? sym1 sym2) 0
       (if (string<? (symbol->string sym1) (symbol->string sym2)) -1 +1)))
+
+(define (real-number-equality num1 num2)
+  (= num1 num2))
 
 (define (real-number-comparison num1 num2)
   (if (= num1 num2) 0
       (if (< num1 num2) -1 +1)))
 
+(define (complex-number-equality num1 num2)
+  (= num1 num2))
+
 (define (complex-number-comparison num1 num2)
   (or= (real-number-comparison (real-part num1) (real-part num2))
        (real-number-comparison (imag-part num1) (imag-part num2))))
+
+
+;; Pair cars and cdrs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (make-car-comparison compare)
+  (lambda (pair1 pair2)
+    (compare (car pair1) (car pair2))))
+
+(define (make-cdr-comparison compare)
+  (lambda (pair1 pair2)
+    (compare (cdr pair1) (cdr pair2))))
 
 
 ;; Pairs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/srfi-114/srfi/114/standard-procedures.scm
+++ b/srfi-114/srfi/114/standard-procedures.scm
@@ -14,12 +14,18 @@
 
 (define (null-comparison null1 null2) 0)
 
+(define (null-hash null)
+  (srfi-69:hash-by-identity null))
+
 (define (boolean-equality bool1 bool2)
   (eq? bool1 bool2))
 
 (define (boolean-comparison bool1 bool2)
   (if (eq? bool1 bool2) 0
       (if (eq? bool1 #f) -1 +1)))
+
+(define (boolean-hash bool)
+  (srfi-69:hash-by-identity bool))
 
 (define (char-equality char1 char2)
   (char=? char1 char2))
@@ -28,12 +34,18 @@
   (if (char=? char1 char2) 0
       (if (char<? char1 char2) -1 +1)))
 
+(define (char-hash char)
+  (srfi-69:hash char))
+
 (define (char-ci-equality char1 char2)
   (char-ci=? char1 char2))
 
 (define (char-ci-comparison char1 char2)
   (if (char-ci=? char1 char2) 0
       (if (char-ci<? char1 char2) -1 +1)))
+
+(define (char-ci-hash char)
+  (srfi-69:hash (char-foldcase char)))
 
 (define (string-equality str1 str2)
   (string=? str1 str2))
@@ -42,12 +54,18 @@
   (if (string=? str1 str2) 0
       (if (string<? str1 str2) -1 +1)))
 
+(define (string-hash str)
+  (srfi-69:string-hash str))
+
 (define (string-ci-equality str1 str2)
   (string-ci=? str1 str2))
 
 (define (string-ci-comparison str1 str2)
   (if (string-ci=? str1 str2) 0
       (if (string-ci<? str1 str2) -1 +1)))
+
+(define (string-ci-hash str)
+  (srfi-69:string-ci-hash str))
 
 (define (symbol-equality sym1 sym2)
   (symbol=? sym1 sym2))
@@ -56,6 +74,9 @@
   (if (symbol=? sym1 sym2) 0
       (if (string<? (symbol->string sym1) (symbol->string sym2)) -1 +1)))
 
+(define (symbol-hash sym)
+  (srfi-69:hash-by-identity sym))
+
 (define (real-number-equality num1 num2)
   (= num1 num2))
 
@@ -63,12 +84,18 @@
   (if (= num1 num2) 0
       (if (< num1 num2) -1 +1)))
 
+(define (real-number-hash num)
+  (srfi-69:hash num))
+
 (define (complex-number-equality num1 num2)
   (= num1 num2))
 
 (define (complex-number-comparison num1 num2)
   (or= (real-number-comparison (real-part num1) (real-part num2))
        (real-number-comparison (imag-part num1) (imag-part num2))))
+
+(define (complex-number-hash num)
+  (srfi-69:hash num))
 
 
 ;; Pair cars and cdrs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/srfi-114/srfi/114/standard-procedures.scm
+++ b/srfi-114/srfi/114/standard-procedures.scm
@@ -109,6 +109,7 @@
   (make-pair-comparison default-comparison default-comparison))
 
 (define (make-improper-list-equality equal?)
+  (define pair-equality (make-pair-equality equal? equal?))
   (define (choose-improper-equality obj)
     (cond ((null? obj) (values 0 null-equality))
           ((pair? obj) (values 1 pair-equality))
@@ -121,6 +122,7 @@
           #f))))
 
 (define (make-improper-list-comparison compare)
+  (define pair-comparison (make-pair-comparison compare compare))
   (define (choose-improper-comparison obj)
     (cond ((null? obj) (values 0 null-comparison))
           ((pair? obj) (values 1 pair-comparison))

--- a/srfi-114/test/srfi-114-tests.scm
+++ b/srfi-114/test/srfi-114-tests.scm
@@ -413,7 +413,14 @@
     (test #t (=? equal-only-improper-comparator '(foo . bar) '(foo . bar)))
     (test #f (=? equal-only-improper-comparator 'foo 'bar))
     (test #f (=? equal-only-improper-comparator '(foo bar) '(foo zog)))
-    (test #f (=? equal-only-improper-comparator '(oops . bar) '(foo . bar))))
+    (test #f (=? equal-only-improper-comparator '(oops . bar) '(foo . bar)))
+
+    (define special-improper-comparator (make-improper-list-comparator (obersymbol-comparator 'a)))
+    (test #t (<? special-improper-comparator '(b . c) '(b . d)))
+    (test #t (<? special-improper-comparator '(b . c) '(c . a)))
+    (test #t (<? special-improper-comparator '(b . c) '(c . a)))
+    (test #f (<? special-improper-comparator '(a . b) '(c . d)))
+    (test #f (<? special-improper-comparator '(a . a) '(a . d))))
 
   (test-group "make-{selecting,refining,reverse}-comparator"
     ;; make-selecting-comparator

--- a/srfi-114/test/srfi-114-tests.scm
+++ b/srfi-114/test/srfi-114-tests.scm
@@ -76,7 +76,12 @@
   (test #t (<? bytevector-comparator #u8()      #u8(1 2 3)))
   (test #t (<? bytevector-comparator #u8(6 6)   #u8(1 1 1)))
   (test #t (=? bytevector-comparator #u8(1 2 3) #u8(1 2 3)))
-  (test #t (<? bytevector-comparator #u8(1 2 3) #u8(1 2 4))))
+  (test #t (<? bytevector-comparator #u8(1 2 3) #u8(1 2 4)))
+
+  (test #t (= (comparator-hash char-ci-comparator #\a)
+              (comparator-hash char-ci-comparator #\A)))
+  (test #t (= (comparator-hash string-ci-comparator "FooBar")
+              (comparator-hash string-ci-comparator "foobar"))))
 
 (test-group "The default comparator"
   (test #t (<? default-comparator '() '(a . d) '#false #\space "string" 'zorro 42 #(9) #u8() cons))

--- a/tools/install-dependencies
+++ b/tools/install-dependencies
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -ex
+
+[ -z $SRFI_60_FORK ]   && SRFI_60_FORK=ilammy/srfi-60
+[ -z $SRFI_60_BRANCH ] && SRFI_60_BRANCH=v1.0.0
+
+cd /tmp/scratch
+git clone --depth 50 --branch $SRFI_60_BRANCH -- https://github.com/$SRFI_60_FORK srfi-60
+
+cd srfi-60
+./tools/make-snowball
+
+snow-chibi --ignore-sig install srfi-60.tgz


### PR DESCRIPTION
This is going to resolve the issue #6. It turned out to be more... extensive than I thought. Too stupid was I writing that code and submitting it as _ready_ to Chibi's mailing list, heh.

Anyway. The issue with equality seems to be resolved by these commits. Now each and every standard comparator has its own explicit equality predicate. The hash functions are the remaining issue. I am currently working on the same thing for them. I will post updates in this pull request.
